### PR TITLE
Update 1067.md

### DIFF
--- a/chapters/lotm/webnovel/1067.md
+++ b/chapters/lotm/webnovel/1067.md
@@ -60,12 +60,12 @@ elves, Sanguine, as well as their slaves.
 The "Early Era of Fire" lasted different periods of time according to
 the different records. However, a common point was that it lasted less
 than a thousand years, as the essence of the ancient gods was madness,
-tyranny, cruel, and cold. They were often driven by their instinct.
+tyranny, cruelty, and coldness. They were often driven by their instinct.
 
 After the Sanguine Ancestor Lilith, Mutant King Kvastir, and
 Annihilation Demonic Wolf Flegrea perished during the betrayal, the
-"E3rly Elm of Fire" ended, and the war broke out "The world was damaged,
-and it didiVt stop for centuries.
+"Early Era of Fire" ended, and the war broke out "The world was damaged,
+and it didn't stop for centuries.
 
 Due to the fact that the giants and dragons were relatively strong in
 this period of time, they were known as the "Dual Era."


### PR DESCRIPTION
Typos and maintaining parallel structure. The use of nouns and adjectives together doesn't seem to deliberate since parallel structure is used for similar sentence in a later paragraph.
 "madness, tyranny, cruel, and cold." -> "tyranny, cruelty, coldness, and slaughtering"