### PR TITLE
Corrected spelling of "Evernight"

### DIFF
--- a/chapters/lotm/oldtl/1012.md
+++ b/chapters/lotm/oldtl/1012.md
@@ -86,7 +86,7 @@ the way it thinks.
 
 "Thanks to some of its answers, I've found a way to create pure
 darkness. It is to create it with a charm of the Evernight domain that
-has dreamworld properties. It's considered a response of the Evemight
+has dreamworld properties. It's considered a response of the Evernight
 Goddess and is categorized under pure darkness. In addition, after
 repeated tests, I've finally figured out the way to carve the godhood
 symbols through Cogitation and create the item I want."

--- a/chapters/lotm/oldtl/1029.md
+++ b/chapters/lotm/oldtl/1029.md
@@ -41,7 +41,7 @@ Klein looked at his new marionette and exhaled silently. He looked up at
 the clear and bright red moon and said, "It's done."
 
 Amidst the gigantic crimson moon, a black dot instantly appeared and
-descended from the sky. It was none other than the Church of Evemight's
+descended from the sky. It was none other than the Church of Evernight's
 archbishop, Servant of Concealment, Arianna, who wore a simple robe with
 tree bark as a belt.
 

--- a/chapters/lotm/oldtl/1048.md
+++ b/chapters/lotm/oldtl/1048.md
@@ -123,7 +123,7 @@ where you can be cleansed to a certain degree. But he didn't ask you to
 avoid the Church of Evernight's archbishop. You can use this to create
 an opportunity. Meet the archbishop; of course, there's no need to say
 anything. This way, when Hvin Rambis dies or vanishes, the Psychology
-Alchemists will most probably suspect that the Church of Evemight had
+Alchemists will most probably suspect that the Church of Evernight had
 detected something wrong with you and had set up a trap."
 
 Without waiting for Miss Justice to respond, he looked at Xio.
@@ -134,7 +134,7 @@ spy sent by the Church of Evernight to infiltrate the Tarot Club. This
 will misdirect the Psychology Alchemists into believing that the matters
 pertaining to Hvin Rambis were done by the Tarot Club, but was in fact a
 smokescreen. The true mastermind behind all of this is the Church of
-Evemight..."
+Evernight..."
 
 Acting like a spy in the Tarot Club that was sent by the Church of
 Evernight... Well... Klein felt a little guilty.

--- a/chapters/lotm/oldtl/1075.md
+++ b/chapters/lotm/oldtl/1075.md
@@ -206,7 +206,7 @@ facing the Dark Sacred Emblem. Closing his eyes in the tranquil
 environment, he focused on chanting the Goddess's honorific name in
 ancient Hermes.
 
-"The Evemight Goddess who stands higher than the cosmos and more eternal
+"The Evernight Goddess who stands higher than the cosmos and more eternal
 than eternity. You are also the Lady of Crimson, the Mother of
 Concealment, the Empress of Misfortune and Horror, Mistress of Repose
 and Silence..."

--- a/chapters/lotm/oldtl/1104.md
+++ b/chapters/lotm/oldtl/1104.md
@@ -133,7 +133,7 @@ Pallez Zoroast laughed and said, "Balance also means that everyone will
 be very restrained. Besides, it's very likely that Amon won't let 'His'
 true body enter Backlund. At most, 'He' will send a large number of
 avatars over. After all, the impossibility of a divine descent by
-Evemight doesn't mean that Storm or Steam can't."
+Evernight doesn't mean that Storm or Steam can't."
 
 "What do you mean?" Leonard acutely grasped the key point in Old Man's
 words.
@@ -141,7 +141,7 @@ words.
 Pallez Zoroast's tone suddenly became more relaxed.
 
 "Regardless of whether it's because of the war or for other reasons,
-Evemight is likely unable to interfere with the matters on the ground at
+Evernight is likely unable to interfere with the matters on the ground at
 the moment. Otherwise, why would 'She' need to lure Amon over to form a
 balance? 'She' directly set up a trap, and who knows, 'She' might be
 able to capture Zaratul or scare the cowardly Seer away."

--- a/chapters/lotm/oldtl/1105.md
+++ b/chapters/lotm/oldtl/1105.md
@@ -121,7 +121,7 @@ long, mottled table with his fingers. He was increasingly puzzled about
 what was happening underground.
 
 Fortunately, Hermes's description, the state of the abandoned castle,
-and the attitude of the Evemight Goddess seemed to indicate that the
+and the attitude of the Evernight Goddess seemed to indicate that the
 corruption that stems from underground would naturally dissipate.
 Leaving it alone was the best solution.
 

--- a/chapters/lotm/oldtl/1131.md
+++ b/chapters/lotm/oldtl/1131.md
@@ -186,7 +186,7 @@ The real explanation in his heart was that an ancient race like the
 Sanguine, who had lived for several years, definitely had some
 connections with the various Churches, especially when the Sanguine
 Queen was still the Night Emperor's queen. At that time, the Church of
-Evemight had supported the Night Emperor.
+Evernight had supported the Night Emperor.
 
 Emlyn also thought of this and nodded slightly.
 

--- a/chapters/lotm/webnovel/1012.md
+++ b/chapters/lotm/webnovel/1012.md
@@ -85,7 +85,7 @@ the way it thinks.
 
 "Thanks to some of its answers, I've found a way to create pure
 darkness. It is to create it with a charm of the Evernight domain that
-has dreamworld properties. It's considered a response of the Evemight
+has dreamworld properties. It's considered a response of the Evernight
 Goddess and is categorized under pure darkness. In addition, after
 repeated tests, I've finally figured out the way to carve the godhood
 symbols through Cogitation and create the item I want."

--- a/chapters/lotm/webnovel/1029.md
+++ b/chapters/lotm/webnovel/1029.md
@@ -41,7 +41,7 @@ Klein looked at his new marionette and exhaled silently. He looked up at
 the clear and bright red moon and said, "It's done."
 
 Amidst the gigantic crimson moon, a black dot instantly appeared and
-descended from the sky. It was none other than the Church of Evemight's
+descended from the sky. It was none other than the Church of Evernight's
 archbishop, Servant of Concealment, Arianna, who wore a simple robe with
 tree bark as a belt.
 

--- a/chapters/lotm/webnovel/1048.md
+++ b/chapters/lotm/webnovel/1048.md
@@ -123,7 +123,7 @@ where you can be cleansed to a certain degree. But he didn't ask you to
 avoid the Church of Evernight's archbishop. You can use this to create
 an opportunity. Meet the archbishop; of course, there's no need to say
 anything. This way, when Hvin Rambis dies or vanishes, the Psychology
-Alchemists will most probably suspect that the Church of Evemight had
+Alchemists will most probably suspect that the Church of Evernight had
 detected something wrong with you and had set up a trap."
 
 Without waiting for Miss Justice to respond, he looked at Xio.
@@ -134,7 +134,7 @@ spy sent by the Church of Evernight to infiltrate the Tarot Club. This
 will misdirect the Psychology Alchemists into believing that the matters
 pertaining to Hvin Rambis were done by the Tarot Club, but was in fact a
 smokescreen. The true mastermind behind all of this is the Church of
-Evemight..."
+Evernight..."
 
 Acting like a spy in the Tarot Club that was sent by the Church of
 Evernight... Well... Klein felt a little guilty.

--- a/chapters/lotm/webnovel/1075.md
+++ b/chapters/lotm/webnovel/1075.md
@@ -206,7 +206,7 @@ facing the Dark Sacred Emblem. Closing his eyes in the tranquil
 environment, he focused on chanting the Goddess's honorific name in
 ancient Hermes.
 
-"The Evemight Goddess who stands higher than the cosmos and more eternal
+"The Evernight Goddess who stands higher than the cosmos and more eternal
 than eternity. You are also the Lady of Crimson, the Mother of
 Concealment, the Empress of Misfortune and Horror, Mistress of Repose
 and Silence..."

--- a/chapters/lotm/webnovel/1104.md
+++ b/chapters/lotm/webnovel/1104.md
@@ -133,7 +133,7 @@ Pallez Zoroast laughed and said, "Balance also means that everyone will
 be very restrained. Besides, it's very likely that Amon won't let 'His'
 true body enter Backlund. At most, 'He' will send a large number of
 avatars over. After all, the impossibility of a divine descent by
-Evemight doesn't mean that Storm or Steam can't."
+Evernight doesn't mean that Storm or Steam can't."
 
 "What do you mean?" Leonard acutely grasped the key point in Old Man's
 words.
@@ -141,7 +141,7 @@ words.
 Pallez Zoroast's tone suddenly became more relaxed.
 
 "Regardless of whether it's because of the war or for other reasons,
-Evemight is likely unable to interfere with the matters on the ground at
+Evernight is likely unable to interfere with the matters on the ground at
 the moment. Otherwise, why would 'She' need to lure Amon over to form a
 balance? 'She' directly set up a trap, and who knows, 'She' might be
 able to capture Zaratul or scare the cowardly Seer away."

--- a/chapters/lotm/webnovel/1105.md
+++ b/chapters/lotm/webnovel/1105.md
@@ -121,7 +121,7 @@ long, mottled table with his fingers. He was increasingly puzzled about
 what was happening underground.
 
 Fortunately, Hermes's description, the state of the abandoned castle,
-and the attitude of the Evemight Goddess seemed to indicate that the
+and the attitude of the Evernight Goddess seemed to indicate that the
 corruption that stems from underground would naturally dissipate.
 Leaving it alone was the best solution.
 

--- a/chapters/lotm/webnovel/1131.md
+++ b/chapters/lotm/webnovel/1131.md
@@ -186,7 +186,7 @@ The real explanation in his heart was that an ancient race like the
 Sanguine, who had lived for several years, definitely had some
 connections with the various Churches, especially when the Sanguine
 Queen was still the Night Emperor's queen. At that time, the Church of
-Evemight had supported the Night Emperor.
+Evernight had supported the Night Emperor.
 
 Emlyn also thought of this and nodded slightly.
 


### PR DESCRIPTION
Noticed that Evernight was getting misspelled as Evemight. Updating to fix these typos.