### PR TITLE
Small grammatical fixes, chapter 29.md

### DIFF
--- a/chapters/lotm/webnovel/0029.md
+++ b/chapters/lotm/webnovel/0029.md
@@ -64,9 +64,9 @@ He took a deep breath and slowly breathed out.
 "No matter how bad it is, it can't be worse than making an
 eighteen-year-old high-school student decide on his future career..."
 Klein gave a self-deprecating chuckle. Gathering his scattered thoughts,
-his opened the door softly and laid back on the bed.
+he opened the door softly and lay back on the bed.
 
-He laid there with his eyes open, silently looking at the bottom of the
+He lay there with his eyes open, silently looking at the bottom of the
 top bunk that was dyed with the faint crimson of the moon.
 
 A drunkard staggered outside the window as a carriage sped down the


### PR DESCRIPTION
1. Pronoun form error fixed: "his opened the door" --> "he opened the door"
2. Verb form errors fixed (2): laid --> lay
---Explanation: The context of both instances involve an individual resting in a horizontal position (synonymous to rest/recline). However, the past tense of the verb "to lay" (meaning to set down something) is used instead of the past tense of "to lie" (meaning to recline). Source: https://www.merriam-webster.com/dictionary/lie#usage-discussion-1